### PR TITLE
CheckRoles guard against null/undefined role list

### DIFF
--- a/src/authentication-context.js
+++ b/src/authentication-context.js
@@ -177,6 +177,9 @@ class AuthenticationContext {
     if (!this.isAuthenticated()) {
       return false
     }
+    if (!this.user.profile.roles) {
+      return false
+    }
     if (typeof roles === 'string') {
       roles = [roles]
     }


### PR DESCRIPTION
From our AzureAD there is no 'roles' property defined on the this.user.profile object and as such I was getting an error that indexOf was not defined when the role check was being performed.
I have added a guard against a null or missing roles list so that role checks fail if the user's profile has no roles.